### PR TITLE
build: reconfigure kokoro for new repo name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ Thanks for stopping by to let us know something could be better!
 
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
-  - Search the issues already opened: https://github.com/googleapis/google-cloud-kvstore/issues
+  - Search the issues already opened: https://github.com/googleapis/nodejs-datastore-kvstore/issues
   - Search the issues on our "catch-all" repository: https://github.com/googleapis/google-cloud-node
   - Search StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform+node.js
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
-- [ ] Make sure to open an issue as a [bug/issue](https://github.com//issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
+- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-kvstore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)

--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/continuous/node10/common.cfg
+++ b/.kokoro/continuous/node10/common.cfg
@@ -21,7 +21,7 @@ before_action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/continuous/node10/docs.cfg
+++ b/.kokoro/continuous/node10/docs.cfg
@@ -1,4 +1,4 @@
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/docs.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/docs.sh"
 }

--- a/.kokoro/continuous/node10/lint.cfg
+++ b/.kokoro/continuous/node10/lint.cfg
@@ -1,4 +1,4 @@
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/lint.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/lint.sh"
 }

--- a/.kokoro/continuous/node10/samples-test.cfg
+++ b/.kokoro/continuous/node10/samples-test.cfg
@@ -3,5 +3,5 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/samples-test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/samples-test.sh"
 }

--- a/.kokoro/continuous/node10/system-test.cfg
+++ b/.kokoro/continuous/node10/system-test.cfg
@@ -3,5 +3,5 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/system-test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/system-test.sh"
 }

--- a/.kokoro/continuous/node12/common.cfg
+++ b/.kokoro/continuous/node12/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/continuous/node8/common.cfg
+++ b/.kokoro/continuous/node8/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/presubmit/node10/common.cfg
+++ b/.kokoro/presubmit/node10/common.cfg
@@ -21,7 +21,7 @@ before_action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/presubmit/node10/docs.cfg
+++ b/.kokoro/presubmit/node10/docs.cfg
@@ -1,4 +1,4 @@
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/docs.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/docs.sh"
 }

--- a/.kokoro/presubmit/node10/lint.cfg
+++ b/.kokoro/presubmit/node10/lint.cfg
@@ -1,4 +1,4 @@
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/lint.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/lint.sh"
 }

--- a/.kokoro/presubmit/node10/samples-test.cfg
+++ b/.kokoro/presubmit/node10/samples-test.cfg
@@ -3,5 +3,5 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/samples-test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/samples-test.sh"
 }

--- a/.kokoro/presubmit/node10/system-test.cfg
+++ b/.kokoro/presubmit/node10/system-test.cfg
@@ -3,5 +3,5 @@ gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-nodejs"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/system-test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/system-test.sh"
 }

--- a/.kokoro/presubmit/node12/common.cfg
+++ b/.kokoro/presubmit/node12/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/presubmit/node8/common.cfg
+++ b/.kokoro/presubmit/node8/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,5 +20,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/test.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/test.sh"
 }

--- a/.kokoro/presubmit/windows/test.cfg
+++ b/.kokoro/presubmit/windows/test.cfg
@@ -1,2 +1,2 @@
 # Use the test file directly
-build_file: "google-cloud-kvstore/.kokoro/test.bat"
+build_file: "nodejs-datastore-kvstore/.kokoro/test.bat"

--- a/.kokoro/release/docs.cfg
+++ b/.kokoro/release/docs.cfg
@@ -18,9 +18,9 @@ env_vars: {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/release/docs.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/release/docs.sh"
 }

--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -60,7 +60,7 @@ before_action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "google-cloud-kvstore/.kokoro/trampoline.sh"
+build_file: "nodejs-datastore-kvstore/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -70,5 +70,5 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-cloud-kvstore/.kokoro/publish.sh"
+    value: "github/nodejs-datastore-kvstore/.kokoro/publish.sh"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs-test": "linkinator docs",
     "predocs-test": "npm run docs"
   },
-  "repository": "googleapis/google-cloud-kvstore",
+  "repository": "googleapis/nodejs-datastore-kvstore",
   "keywords": [
     "gcloud",
     "google",

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2019-10-30T22:14:40.284760Z",
+  "updateTime": "2019-11-20T00:06:44.825904Z",
   "sources": [
     {
       "template": {


### PR DESCRIPTION
the repo was renamed so kokoro needed to be reconfigured, npm publication should continue working appropriately as this is based on the package name.

fixes #165 